### PR TITLE
Update landscape.yml

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -834,7 +834,6 @@ landscape:
             homepage_url: https://www.deepspeed.ai/
             logo: DeepSpeed_light.svg
             repo_url: https://github.com/microsoft/DeepSpeed
-            crunchbase: https://www.crunchbase.com/organization/hugging-face
           - item:
             name: FairScale
             description: PyTorch extension library for high performance and large scale training. This library extends basic PyTorch capabilities while adding new SOTA scaling techniques. 


### PR DESCRIPTION
Deepspeed is not directly associated with Hugggingface.

Main supporters are Snowflake and Microsoft, but there are several other orgs.